### PR TITLE
SPR feat: add layouts and sidebar structure

### DIFF
--- a/src/app/(app)/favorites/page.tsx
+++ b/src/app/(app)/favorites/page.tsx
@@ -1,0 +1,5 @@
+const Favorites = () => {
+  return <div>Favorites</div>
+}
+
+export default Favorites

--- a/src/app/(app)/home/page.tsx
+++ b/src/app/(app)/home/page.tsx
@@ -1,0 +1,5 @@
+const Home = () => {
+  return <div>Home</div>
+}
+
+export default Home

--- a/src/app/(app)/layout.module.scss
+++ b/src/app/(app)/layout.module.scss
@@ -1,0 +1,17 @@
+.layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.main {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.content {
+  flex: 1;
+  overflow: auto;
+  padding: 24px;
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,19 @@
+import { Header } from '@/widgets/header'
+import { SidebarMenu } from '@/widgets/sidebar'
+import s from './layout.module.scss'
+
+export default function AppLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <div className={s.layout}>
+      <Header is_auth />
+      <div className={s.main}>
+        <SidebarMenu />
+        <main className={s.content}>{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/messenger/page.tsx
+++ b/src/app/(app)/messenger/page.tsx
@@ -1,0 +1,5 @@
+const Messenger = () => {
+  return <div>Messenger</div>
+}
+
+export default Messenger

--- a/src/app/(app)/new-post/page.tsx
+++ b/src/app/(app)/new-post/page.tsx
@@ -1,0 +1,5 @@
+const NewPost = () => {
+  return <div>NewPost</div>
+}
+
+export default NewPost

--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -1,0 +1,5 @@
+const Profile = () => {
+  return <div>My Profile</div>
+}
+
+export default Profile

--- a/src/app/(app)/search/page.tsx
+++ b/src/app/(app)/search/page.tsx
@@ -1,0 +1,5 @@
+const Search = () => {
+  return <div>Search</div>
+}
+
+export default Search

--- a/src/app/(app)/statistics/page.tsx
+++ b/src/app/(app)/statistics/page.tsx
@@ -1,0 +1,5 @@
+const Statistics = () => {
+  return <div>Statistics</div>
+}
+
+export default Statistics

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,14 @@
+import { Header } from '@/widgets/header'
+
+export default function AuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <div>
+      <Header is_auth />
+      <main>{children}</main>
+    </div>
+  )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,5 @@
+const Login = () => {
+  return <div>Login</div>
+}
+
+export default Login

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,5 @@
+const SignUp = () => {
+  return <div>SignUp</div>
+}
+
+export default SignUp

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,6 +1,6 @@
 import { Header } from '@/widgets/header'
 
-export default function AuthLayout({
+export default function PublicLayout({
   children,
 }: Readonly<{
   children: React.ReactNode

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,14 @@
+import { Header } from '@/widgets/header'
+
+export default function AuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <div>
+      <Header />
+      <main>{children}</main>
+    </div>
+  )
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,5 @@
+const page = () => {
+  return <div>Hello SPAртанцы</div>
+}
+
+export default page

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.scss'
-import { Header } from '@/widgets/header'
 import StoreProvider from '@/app/providers/StoreProvider'
 
 const interSans = Inter({
@@ -22,10 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${interSans.variable} antialiased`}>
-        <StoreProvider>
-          <Header />
-          {children}
-        </StoreProvider>
+        <StoreProvider>{children}</StoreProvider>
       </body>
     </html>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,0 @@
- const page = () => {
-
-   return <div>Hello SPAртанцы
-  </div>
-}
-
-export default page

--- a/src/shared/api/base/baseApi.ts
+++ b/src/shared/api/base/baseApi.ts
@@ -2,6 +2,7 @@ import { fetchBaseQuery } from '@reduxjs/toolkit/query'
 import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { Mutex } from 'async-mutex'
 import { createApi } from '@reduxjs/toolkit/query/react'
+import { PATHS } from '@/shared/const/path/paths'
 
 /* Мьютекс используется для предотвращения одновременных запросов на обновление токена */
 const mutex = new Mutex()
@@ -63,9 +64,9 @@ export const baseQueryWithReauth: BaseQueryFn<
           /* удаляем expired token */
           sessionStorage.removeItem('accessToken')
           /* убеждаемся, что код выполняется в браузере, а не на сервере и что мы не находимся на странице логина */
-          if (typeof window !== 'undefined' && window.location.pathname !== '/auth/login') {
+          if (typeof window !== 'undefined' && window.location.pathname !== PATHS.AUTH.LOGIN) {
             /* полностью перезагружаем страницу */
-            window.location.href = '/auth/login'
+            window.location.href = PATHS.AUTH.LOGIN
           }
         }
       } finally {

--- a/src/shared/const/path/paths.ts
+++ b/src/shared/const/path/paths.ts
@@ -1,0 +1,16 @@
+export const PATHS = {
+  APP: {
+    HOME: '/home',
+    NEW_POST: '/new-post',
+    PROFILE: '/profile',
+    MESSENGER: '/messenger',
+    SEARCH: '/search',
+    STATISTICS: '/statistics',
+    FAVORITES: '/favorites',
+  },
+
+  AUTH: {
+    LOGIN: '/login',
+    SIGN_UP: '/sign-up',
+  },
+}

--- a/src/widgets/sidebar/index.ts
+++ b/src/widgets/sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './ui/SidebarMenu/SidebarMenu'

--- a/src/widgets/sidebar/model/types/sidebar.types.ts
+++ b/src/widgets/sidebar/model/types/sidebar.types.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+export type SidebarItemType = {
+  activeIcon: ReactNode
+  defaultIcon: ReactNode
+  href: string
+  id: string
+  isDisabled?: boolean
+  text: string
+  withSeparator?: boolean
+}

--- a/src/widgets/sidebar/ui/SidebarMenu/SidebarMenu.tsx
+++ b/src/widgets/sidebar/ui/SidebarMenu/SidebarMenu.tsx
@@ -1,0 +1,91 @@
+'use client'
+import { Button, Sidebar } from '@/shared/ui'
+import { usePathname } from 'next/navigation'
+import { SidebarMenuList } from '@/widgets/sidebar/ui/SidebarMenuList/SidebarMenuList'
+import {
+  Bookmark,
+  BookmarkOutline,
+  Home,
+  HomeOutline,
+  Layers,
+  LayersOutline,
+  LogOut,
+  MessageCircle,
+  MessageCircleOutline,
+  PlusSquare,
+  PlusSquareOutline,
+  Search,
+  SearchOutline,
+  TrendingUp,
+  TrendingUpOutline,
+} from '@/shared/assets/icons'
+import type { SidebarItemType } from '@/widgets/sidebar/model/types/sidebar.types'
+import { PATHS } from '@/shared/const/path/paths'
+
+const sidebarItems: SidebarItemType[] = [
+  {
+    id: '1',
+    text: 'Feed',
+    defaultIcon: <HomeOutline />,
+    activeIcon: <Home />,
+    href: PATHS.APP.HOME,
+  },
+  {
+    id: '2',
+    text: 'Create',
+    defaultIcon: <PlusSquareOutline />,
+    activeIcon: <PlusSquare />,
+    href: PATHS.APP.NEW_POST,
+  },
+  {
+    id: '3',
+    text: 'My Profile',
+    defaultIcon: <LayersOutline />,
+    activeIcon: <Layers />,
+    href: PATHS.APP.PROFILE,
+  },
+  {
+    id: '4',
+    text: 'Messenger',
+    defaultIcon: <MessageCircleOutline />,
+    activeIcon: <MessageCircle />,
+    href: PATHS.APP.MESSENGER,
+  },
+  {
+    id: '5',
+    text: 'Search',
+    defaultIcon: <SearchOutline />,
+    activeIcon: <Search />,
+    href: PATHS.APP.SEARCH,
+    withSeparator: true,
+  },
+
+  {
+    id: '6',
+    text: 'Statistics',
+    defaultIcon: <TrendingUpOutline />,
+    activeIcon: <TrendingUp />,
+    href: PATHS.APP.STATISTICS,
+  },
+  {
+    id: '7',
+    text: 'Favorites',
+    defaultIcon: <BookmarkOutline />,
+    activeIcon: <Bookmark />,
+    href: PATHS.APP.FAVORITES,
+  },
+]
+
+export const SidebarMenu = () => {
+  const currentPath = usePathname()
+
+  return (
+    <Sidebar>
+      <SidebarMenuList items={sidebarItems} path={currentPath} />
+      <Button variant={'withIcon'} style={{ marginTop: '180px' }}>
+        <LogOut />
+        Log Out
+      </Button>
+    </Sidebar>
+  )
+}

--- a/src/widgets/sidebar/ui/SidebarMenuList/SidebarMenuList.module.scss
+++ b/src/widgets/sidebar/ui/SidebarMenuList/SidebarMenuList.module.scss
@@ -1,0 +1,13 @@
+.sidebarNav {
+  padding: 0 30px 0 60px;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  justify-content: center;
+}

--- a/src/widgets/sidebar/ui/SidebarMenuList/SidebarMenuList.tsx
+++ b/src/widgets/sidebar/ui/SidebarMenuList/SidebarMenuList.tsx
@@ -1,0 +1,31 @@
+import { SidebarItem } from '@/shared/ui'
+import Link from 'next/link'
+import s from './SidebarMenuList.module.scss'
+import type { SidebarItemType } from '@/widgets/sidebar/model/types/sidebar.types'
+
+type Props = {
+  items: SidebarItemType[]
+  path: string
+}
+
+export const SidebarMenuList = ({ items, path }: Props) => {
+  const onItemClickHandler = (href: string) => {
+    return href === path
+  }
+  return (
+    <nav className={s.sidebarNav}>
+      <ul className={s.list}>
+        {items.map(item => (
+          <SidebarItem
+            href={item.href}
+            as={Link}
+            key={item.id}
+            item={item}
+            isActive={onItemClickHandler(item.href)}
+            onItemClick={onItemClickHandler}
+          />
+        ))}
+      </ul>
+    </nav>
+  )
+}


### PR DESCRIPTION
Вариант начальной структуры проекта

- 3 независимых `layouts `(app, auth, public) + `RootLayout `с основными тегами
- папки не включаются в url-путь - реализовано через `Route Groups`
- компонент `SidebarMenu `для базовой навигации
- заготовки основных страниц, отображаемых в `Sidebar`

![Screenshot 2025-06-08 203642](https://github.com/user-attachments/assets/02493c94-1a3c-4e3d-ada3-da93855ed28e)